### PR TITLE
Update robovm version to 2.3.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <robovm.version>2.3.12-SNAPSHOT</robovm.version>
+        <robovm.version>2.3.12</robovm.version>
         <robopods.version>${project.version}</robopods.version>
         <skipTests>true</skipTests>
     </properties>


### PR DESCRIPTION
**The problem:**

AltPods are impossible to use at the moment. There is a problem with peer dependency:

![image](https://user-images.githubusercontent.com/31850900/111006106-6fd7b600-838c-11eb-9335-da14687516df.png)

There is no 2.3.12-SNAPSHOT version in sonatype snapshots repository: https://oss.sonatype.org/content/repositories/snapshots/com/mobidevelop/robovm/robovm-cocoatouch/2.3.12-SNAPSHOT/maven-metadata.xml

**Fix proposal:**

Update robovm to 2.3.12

